### PR TITLE
Fix Nether and End portals for non-player entities

### DIFF
--- a/patches/server/0001-new-fork-who-dis-Rebrand-to-SparklyPaper-and-Build-C.patch
+++ b/patches/server/0001-new-fork-who-dis-Rebrand-to-SparklyPaper-and-Build-C.patch
@@ -3,8 +3,9 @@ From: MrPowerGamerBR <git@mrpowergamerbr.com>
 Date: Sat, 12 Jun 2021 16:40:34 +0200
 Subject: [PATCH] new fork who dis - Rebrand to SparklyPaper and Build Changes
 
+
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 58da26ad2f128ba0b66f86820f60853f4be352f0..f2c2d7af8d3647879702c27e8a0ee62e76afd6e7 100644
+index 241808d8619e17c0681f79acbbc98af5bf52dd89..d7bf3d87a67f44da74c4ff2788c0726b6394cf57 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -3,6 +3,8 @@ import io.papermc.paperweight.util.*
@@ -15,10 +16,10 @@ index 58da26ad2f128ba0b66f86820f60853f4be352f0..f2c2d7af8d3647879702c27e8a0ee62e
 +    kotlin("plugin.serialization") version "1.9.10"
      id("com.github.johnrengelman.shadow")
  }
-
+ 
 @@ -13,8 +15,15 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
  val alsoShade: Configuration by configurations.creating
-
+ 
  dependencies {
 -    implementation(project(":paper-api"))
 -    implementation(project(":paper-mojangapi"))
@@ -34,7 +35,7 @@ index 58da26ad2f128ba0b66f86820f60853f4be352f0..f2c2d7af8d3647879702c27e8a0ee62e
      // Paper start
      implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
-@@ -64,13 +73,18 @@ tasks.jar {
+@@ -65,13 +74,18 @@ tasks.jar {
      manifest {
          val git = Git(rootProject.layout.projectDirectory.path)
          val gitHash = git("rev-parse", "--short=7", "HEAD").getText().trim()
@@ -55,7 +56,7 @@ index 58da26ad2f128ba0b66f86820f60853f4be352f0..f2c2d7af8d3647879702c27e8a0ee62e
              "Implementation-Vendor" to date, // Paper
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
-@@ -154,7 +168,7 @@ fun TaskContainer.registerRunTask(
+@@ -155,7 +169,7 @@ fun TaskContainer.registerRunTask(
      name: String,
      block: JavaExec.() -> Unit
  ): TaskProvider<JavaExec> = register<JavaExec>(name) {

--- a/patches/server/0003-Optimize-entity-coordinate-key.patch
+++ b/patches/server/0003-Optimize-entity-coordinate-key.patch
@@ -24,10 +24,10 @@ index 850f75172e9efa72cabb8e5bd124b96a0b1a945f..3db1de70c76e1427e257d988d1a7f26e
  
      public static long getCoordinateKey(final ChunkPos pair) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 906eded9a2ab61737a30cfe89292a71237ce4eb7..b0b9e07da81ca0c2a0e915afbcd1a50a39e3bf20 100644
+index 45439b0cc4ea69e409fd41d4684403c0e0feab12..b2a5dd7ddeb937b6ad5f9a035ffca6bcb48a6ba4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -308,7 +308,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+@@ -309,7 +309,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
      public double yo;
      public double zo;
      private Vec3 position;

--- a/patches/server/0009-Skip-EntityScheduler-s-executeTick-checks-if-there-i.patch
+++ b/patches/server/0009-Skip-EntityScheduler-s-executeTick-checks-if-there-i.patch
@@ -115,10 +115,10 @@ index 8f250966ab5e4576e3a57beba2e417d53713e84e..3aab37ae2ef5a359b09c885f0988aa7b
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.CALLBACK_MANAGER.handleQueue(this.tickCount); // Paper
          this.profiler.push("commandFunctions");
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 8698104e3eb98e2cc5da5de87a8f538860c1d91d..72debf1e3da28531420e13b3c2eb8ef0cfe070d0 100644
+index 0b5a31477e3b76833fb97a455842316193663c8e..06da726986d023855f74eeb365e6921fdaeafea4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -68,7 +68,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -69,7 +69,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
      protected net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
      // Paper start - Folia shedulers
@@ -127,7 +127,7 @@ index 8698104e3eb98e2cc5da5de87a8f538860c1d91d..72debf1e3da28531420e13b3c2eb8ef0
      private final io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler apiScheduler = new io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler(this);
  
      @Override
-@@ -81,6 +81,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -82,6 +82,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          this.server = server;
          this.entity = entity;
          this.entityType = CraftEntityType.minecraftToBukkit(entity.getType());

--- a/patches/server/0018-Parallel-world-ticking.patch
+++ b/patches/server/0018-Parallel-world-ticking.patch
@@ -819,7 +819,7 @@ index 53bce70f5cc14672d41618747d3919429896001f..ec27e20d661ecde3992a4b4366cf19b2
                      }
                  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9a1f5ce72dbe116c31d9f72a8ad2dfaedf962d7d..919f49c4dac25fe129cb0d7ddfd63932aff89c17 100644
+index 3ec103bad1356c7851bbb6271d04bcb0cbe994a6..996b690207a7bb9f7ddd1150d4855b6290074735 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -217,6 +217,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -964,10 +964,10 @@ index 58591bf2f63b9c5e97d9ce4188dff3366968a178..3debae03ef3d6e01699be2f49a43835f
          // Paper end - Inventory close reason
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 91feb12732564c90656da487664dbc12e55397fc..7dc3355c7a40081498b4a3c6a6dca7edd151e59b 100644
+index 1e5f709115007ff19901c0a6c3cf884d9e4d3a6c..5d1b1da365a8a932094dfc3419019df6fd25ed5b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -134,7 +134,7 @@ public abstract class PlayerList {
+@@ -135,7 +135,7 @@ public abstract class PlayerList {
      private static final SimpleDateFormat BAN_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
      private final MinecraftServer server;
      public final List<ServerPlayer> players = new java.util.concurrent.CopyOnWriteArrayList(); // CraftBukkit - ArrayList -> CopyOnWriteArrayList: Iterator safety
@@ -976,7 +976,7 @@ index 91feb12732564c90656da487664dbc12e55397fc..7dc3355c7a40081498b4a3c6a6dca7ed
      private final UserBanList bans;
      private final IpBanList ipBans;
      private final ServerOpList ops;
-@@ -155,7 +155,7 @@ public abstract class PlayerList {
+@@ -156,7 +156,7 @@ public abstract class PlayerList {
  
      // CraftBukkit start
      private CraftServer cserver;
@@ -985,7 +985,7 @@ index 91feb12732564c90656da487664dbc12e55397fc..7dc3355c7a40081498b4a3c6a6dca7ed
      public @Nullable String collideRuleTeamName; // Paper - Configurable player collision
  
      public PlayerList(MinecraftServer server, LayeredRegistryAccess<RegistryLayer> registryManager, PlayerDataStorage saveHandler, int maxPlayers) {
-@@ -179,6 +179,7 @@ public abstract class PlayerList {
+@@ -180,6 +180,7 @@ public abstract class PlayerList {
      abstract public void loadAndSaveFiles(); // Paper - fix converting txt to json file; moved from DedicatedPlayerList constructor
  
      public void placeNewPlayer(Connection connection, ServerPlayer player, CommonListenerCookie clientData) {
@@ -993,7 +993,7 @@ index 91feb12732564c90656da487664dbc12e55397fc..7dc3355c7a40081498b4a3c6a6dca7ed
          player.isRealPlayer = true; // Paper
          player.loginTime = System.currentTimeMillis(); // Paper - Replace OfflinePlayer#getLastPlayed
          GameProfile gameprofile = player.getGameProfile();
-@@ -817,6 +818,8 @@ public abstract class PlayerList {
+@@ -818,6 +819,8 @@ public abstract class PlayerList {
      }
  
      public ServerPlayer respawn(ServerPlayer entityplayer, ServerLevel worldserver, boolean flag, Location location, boolean avoidSuffocation, RespawnReason reason, org.bukkit.event.player.PlayerRespawnEvent.RespawnFlag...respawnFlags) {
@@ -1002,7 +1002,7 @@ index 91feb12732564c90656da487664dbc12e55397fc..7dc3355c7a40081498b4a3c6a6dca7ed
          // Paper end - Expand PlayerRespawnEvent
          entityplayer.stopRiding(); // CraftBukkit
          this.players.remove(entityplayer);
-@@ -841,6 +844,7 @@ public abstract class PlayerList {
+@@ -842,6 +845,7 @@ public abstract class PlayerList {
          ServerPlayer entityplayer1 = entityplayer;
          org.bukkit.World fromWorld = entityplayer.getBukkitEntity().getWorld();
          entityplayer.wonGame = false;
@@ -1011,10 +1011,10 @@ index 91feb12732564c90656da487664dbc12e55397fc..7dc3355c7a40081498b4a3c6a6dca7ed
  
          entityplayer1.connection = entityplayer.connection;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b0b9e07da81ca0c2a0e915afbcd1a50a39e3bf20..f0db55f14388724d81640e6b4ead2429d11207c9 100644
+index b2a5dd7ddeb937b6ad5f9a035ffca6bcb48a6ba4..46a921568dede70e0cf865112a66003501a16562 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -813,7 +813,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+@@ -826,7 +826,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle
@@ -1023,7 +1023,7 @@ index b0b9e07da81ca0c2a0e915afbcd1a50a39e3bf20..f0db55f14388724d81640e6b4ead2429
              this.handleNetherPortal();
          }
      }
-@@ -3960,6 +3960,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+@@ -3976,6 +3976,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
              this.teleportPassengers();
              this.setYHeadRot(yaw);
          } else {
@@ -1092,7 +1092,7 @@ index 3aa73cd44aa8c86b78c35bc1788e4f83018c49ed..eac9b4148d0951f7c54ce4ad8ab4d97e
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 1008f136ec24efc588b41fe8bf313c926ca000ed..5d73bd30d6c48effd5977c7ae6a4d85d770541cc 100644
+index aa2459f48592c8c960f602ccf84db919ef50cdd9..f7222f8f0a2a2ee4e8c4769d1cccb6cc3a643bcc 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -10,6 +10,8 @@ import java.util.function.Consumer;
@@ -1759,10 +1759,10 @@ index 8afc396c162d928902a9d9beb9f039b06630f755..4cde4be86dc03ebbfb5c12a910acbf99
          // Paper end
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d677759ac6b6d3cfe5a2af76dc1f0034b216ac2d..f9ef030ab07f2da56e3b1689b9ec9dbc37975694 100644
+index 4c2e8129481384a143384d327e14320023735b1a..da3e9f87b48215371444ff481de0db5b5bf6beda 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -941,7 +941,7 @@ public class CraftEventFactory {
+@@ -942,7 +942,7 @@ public class CraftEventFactory {
          return CraftEventFactory.handleBlockSpreadEvent(world, source, target, block, 2);
      }
  
@@ -1771,7 +1771,7 @@ index d677759ac6b6d3cfe5a2af76dc1f0034b216ac2d..f9ef030ab07f2da56e3b1689b9ec9dbc
  
      public static boolean handleBlockSpreadEvent(LevelAccessor world, BlockPos source, BlockPos target, net.minecraft.world.level.block.state.BlockState block, int flag) {
          // Suppress during worldgen
-@@ -953,7 +953,7 @@ public class CraftEventFactory {
+@@ -954,7 +954,7 @@ public class CraftEventFactory {
          CraftBlockState state = CraftBlockStates.getBlockState(world, target, flag);
          state.setData(block);
  
@@ -1780,7 +1780,7 @@ index d677759ac6b6d3cfe5a2af76dc1f0034b216ac2d..f9ef030ab07f2da56e3b1689b9ec9dbc
          Bukkit.getPluginManager().callEvent(event);
  
          if (!event.isCancelled()) {
-@@ -2126,7 +2126,7 @@ public class CraftEventFactory {
+@@ -2142,7 +2142,7 @@ public class CraftEventFactory {
          CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemStack.copyWithCount(1));
  
          org.bukkit.event.block.BlockDispenseEvent event = new org.bukkit.event.block.BlockDispenseEvent(bukkitBlock, craftItem.clone(), CraftVector.toBukkit(to));

--- a/patches/server/0019-Fix-Nether-and-End-portals-for-non-player-entities.patch
+++ b/patches/server/0019-Fix-Nether-and-End-portals-for-non-player-entities.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: alexthvest <alexthvest@gmail.com>
+Date: Sun, 25 Feb 2024 03:09:00 +0300
+Subject: [PATCH] Fix Nether and End portals for non-player entities
+
+Moved changeDimension from ServerLevel tick thread to main tick thread.
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 46a921568dede70e0cf865112a66003501a16562..0e3b9b273173917032ea6897c424201d5380b980 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -467,7 +467,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+             ((ServerPlayer) this).changeDimension(worldserver, PlayerTeleportEvent.TeleportCause.END_PORTAL);
+             return;
+         }
+-        this.teleportTo(worldserver, null);
++
++        getBukkitEntity().taskScheduler.schedule(
++            entity -> entity.teleportTo(worldserver, null),
++            entity -> {},
++            0
++        );
+     }
+     // Paper end - make end portalling safe
+     // Paper start - optimise entity tracking
+@@ -826,7 +831,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+     // CraftBukkit start
+     public void postTick() {
+         // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle
+-        if (false && !(this instanceof ServerPlayer) && this.isAlive()) { // Paper - don't attempt to teleport dead entities // SparklyPaper - parallel world ticking (see issue #9, this is executed in the server level tick for non-player entities)
++        if (!(this instanceof ServerPlayer) && this.isAlive()) { // Paper - don't attempt to teleport dead entities // SparklyPaper - parallel world ticking (see issue #9, this is executed in the server level tick for non-player entities)
+             this.handleNetherPortal();
+         }
+     }
+@@ -3173,7 +3178,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+                     if (this instanceof ServerPlayer) {
+                         ((ServerPlayer) this).changeDimension(worldserver1, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL);
+                     } else {
+-                        this.changeDimension(worldserver1);
++                        var destinationWorldServer = worldserver1;
++                        getBukkitEntity().taskScheduler.schedule(
++                            entity -> entity.changeDimension(destinationWorldServer),
++                            entity -> {},
++                            0
++                        );
+                     }
+                     } // Paper - Add EntityPortalReadyEvent
+                     // CraftBukkit end


### PR DESCRIPTION
I tried to fix problems with non-player entities and portals cause some will need this functionallity on their server (like we're).

The main problem I found that teleportation ticked on ServerLevel tick thread but entities neeed to check Poi in another world. I use taskScheduler to schedule changeDimension on main thread.